### PR TITLE
WIP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,23 +9,6 @@ deps:
 build: $(GOFILES_NOVENDOR)
 	go list ./...  | grep cmd | xargs -P $$(nproc) -n 1 -- go build -i
 
-writer/influxdb/api.proto.influxdb_formatter.go \
-writer/datadog/api.proto.datadog_formatter.go \
-publisher/api.proto.publisher_formatter.go: \
-api/api.proto .codegen/emit.py \
-.codegen/influxdb_formatter.go.jinja2 \
-.codegen/datadog_formatter.go.jinja2 \
-.codegen/publisher_formatter.go.jinja2
-	retool do protoc -I api api/api.proto --plugin=protoc-gen-custom=./.codegen/emit.py --custom_out=.
-	find . -name "api.proto.*_formatter.go" | xargs gofmt -l -w
-
-api/api.pb.go: api/api.proto
-	retool do protoc -I api/ api/api.proto --go_out=plugins=grpc:api
-
-.PHONY: gofiles
-src: $(GOFILES_NOVENDOR) fmt
-	@true
-
 .PHONY: unit
 unit: $(GOFILES_NOVENDOR)
 	go test $$(go list ./... | grep -v /vendor/)
@@ -34,9 +17,3 @@ unit: $(GOFILES_NOVENDOR)
 .PHONY: test
 test: unit
 	@true
-
-.PHONY: fmt
-fmt:
-	gofmt -l -w ${GOFILES_NOVENDOR}
-
-.DEFAULT_GOAL := test

--- a/README.md
+++ b/README.md
@@ -1,37 +1,68 @@
-Mini Collector
-==============
+# mega-collector
 
-Metrics collection and aggregation.
+mega-collector tails log files, and ships those log files to a centralized destination.
+The destinations currently supported are:
+
+* Nowhere (aka blackhole)
+* A file
+
+### mega-collector anatomy
+
+mega-collector has two main components: a collector and an aggregator. The collector tails
+the specified log files and ships the contents of the logs files to the aggregator. The aggregator 
+then ships the those logs to a single specified destination in batches. 
+
+## Aggregator
+
+The entry point for the aggregator is defined in `cmd/aggregator/main.go`. 
+The entry point runs a server (specified in `api/api.pb.go`) that is configured to receive data that
+is in a specific format (defined in `api/api.proto`). 
+The code for this server is auto-generated based on the values in `api/api.proto`. 
+
+The messages the aggregator receives are grouped into batches. There can be at most `AGGREGATOR_MAX_BATCH_SIZE`
+messages in each batch. 
+Once a batch has `AGGREGATOR_MAX_BATCH_SIZE` messages, or `AGGREGATOR_MINIMUM_PUBLISH_FREQUENCY` time has passed,
+the batcher pushes the batch to the destination.
 
 
-Building
---------
+TODO: Add something about the ingestBuffer here
 
-### Build Dependencies
-
-You'll need a few build dependencies:
-
-- Protobuf Compiler
-- Protobuf Python support
-- Protobuf Golang support
-
-To find out how to install those, see `.travis.yml`.
+Pushing to a destination is done via an emitter. The emitter used is determined in the `getEmitter` function
+in `cmd/aggregator/main.go` by the presence of a configuration environment variable.
+  
+(This is not implemented yet, because it's irrelevant for the text output) On failure to push to the destination,
+the emitter will retry X times. After X failures, the data is discarded and a PagerDuty alert is generated.
+(see https://github.com/aptible/mini-collector/blob/master/cmd/aggregator/main.go#L180-L183) 
 
 
-### Building and Testing
-
-Use `make build` and `make test`.
-
-See `Makefile` for more detail.
 
 
-### Building Docker images
+### Aggregator environment variables
 
-To build Docker images, use:
+|  Variable |  Default | Format | Description |
+|-----------|----------|--------|-------|
+| `AGGREGATOR_NOTIFY_CONFIGURATION` | n/a | See [`AGGREGATOR_NOTIFY_CONFIGURATION`](#AGGREGATOR_NOTIFY_CONFIGURATION) | Specifies how we notify PagerDuty of a failure  |
+| `AGGREGATOR_MINIMUM_PUBLISH_FREQUENCY` | 15s | should be parsable by `ParseDuration`: https://golang.org/pkg/time/#ParseDuration | | 
+| `AGGREGATOR_TLS` |  0 | 0 or 1 (false/true) | Indicates whether or not the aggregator should use TLS to communicate with the collectors |
+| `AGGREGATOR_TLS_CERTIFICATE` | n/a | String | |
+| `AGGREGATOR_TLS_KEY` | n/a | String | |
+| `AGGREGATOR_TLS_CA_CERTIFICATE` | n/a | String | |
+| `AGGREGATOR_MAX_BATCH_SIZE` | 1000 | integer | The maximum number of log entries that can be emitted in a single group |
+| `AGGREGATOR_TEXT_CONFIGURATION`  | n/a  | Any truthy value works | The presence of this env variable indicates that logs should be set to stdout |
+|   |   |   |  |
+|   |   |   |  |
 
+
+
+
+## Configuration formats
+
+### `AGGREGATOR_NOTIFY_CONFIGURATION`
+
+```json
+{
+  "integration_key": "String; The PagerDuty integration key",
+  "incident_key": "String; A unique identifier for this drain, e.g. stack/log_drain/ID/notify",
+  "identifier": "String; A human-readable way to identify this drain, e.g. Log Drain #ID (handle)"
+}
 ```
-make -f .docker/Makefile push TAG=aggregator
-make -f .docker/Makefile push TAG=mini-collector
-```
-
-See `.docker/Makefile` for more detail.

--- a/api/api.pb.go
+++ b/api/api.pb.go
@@ -3,13 +3,14 @@
 
 package api
 
-import proto "github.com/golang/protobuf/proto"
-import fmt "fmt"
-import math "math"
-
 import (
-	context "golang.org/x/net/context"
+	context "context"
+	fmt "fmt"
+	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -21,27 +22,13 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
-// NOTE: Protocol buffers used variable-length encoding, so even though uint64
-// is arguably much bigger than we'd need, it's simpler to just use that. We
-// do, however, use signed ints for disk usage and limit because those fields
-// are optional (and should not be reported if they are < 0).
 type PublishRequest struct {
 	UnixTime             int64    `protobuf:"varint,1,opt,name=unix_time,json=unixTime,proto3" json:"unix_time,omitempty"`
-	Running              bool     `protobuf:"varint,2,opt,name=running,proto3" json:"running,omitempty"`
-	MilliCpuUsage        uint64   `protobuf:"varint,3,opt,name=milli_cpu_usage,json=milliCpuUsage,proto3" json:"milli_cpu_usage,omitempty"`
-	MemoryTotalMb        uint64   `protobuf:"varint,4,opt,name=memory_total_mb,json=memoryTotalMb,proto3" json:"memory_total_mb,omitempty"`
-	MemoryRssMb          uint64   `protobuf:"varint,5,opt,name=memory_rss_mb,json=memoryRssMb,proto3" json:"memory_rss_mb,omitempty"`
-	MemoryLimitMb        uint64   `protobuf:"varint,6,opt,name=memory_limit_mb,json=memoryLimitMb,proto3" json:"memory_limit_mb,omitempty"`
-	DiskUsageMb          int64    `protobuf:"zigzag64,7,opt,name=disk_usage_mb,json=diskUsageMb,proto3" json:"disk_usage_mb,omitempty"`
-	DiskLimitMb          int64    `protobuf:"zigzag64,8,opt,name=disk_limit_mb,json=diskLimitMb,proto3" json:"disk_limit_mb,omitempty"`
-	DiskReadKbps         uint64   `protobuf:"varint,9,opt,name=disk_read_kbps,json=diskReadKbps,proto3" json:"disk_read_kbps,omitempty"`
-	DiskWriteKbps        uint64   `protobuf:"varint,10,opt,name=disk_write_kbps,json=diskWriteKbps,proto3" json:"disk_write_kbps,omitempty"`
-	DiskReadIops         uint64   `protobuf:"varint,11,opt,name=disk_read_iops,json=diskReadIops,proto3" json:"disk_read_iops,omitempty"`
-	DiskWriteIops        uint64   `protobuf:"varint,12,opt,name=disk_write_iops,json=diskWriteIops,proto3" json:"disk_write_iops,omitempty"`
-	PidsCurrent          uint64   `protobuf:"varint,13,opt,name=pids_current,json=pidsCurrent,proto3" json:"pids_current,omitempty"`
-	PidsLimit            uint64   `protobuf:"varint,14,opt,name=pids_limit,json=pidsLimit,proto3" json:"pids_limit,omitempty"`
+	Log                  string   `protobuf:"bytes,2,opt,name=log,proto3" json:"log,omitempty"`
+	Time                 string   `protobuf:"bytes,3,opt,name=time,proto3" json:"time,omitempty"`
+	Stream               string   `protobuf:"bytes,4,opt,name=stream,proto3" json:"stream,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -51,16 +38,17 @@ func (m *PublishRequest) Reset()         { *m = PublishRequest{} }
 func (m *PublishRequest) String() string { return proto.CompactTextString(m) }
 func (*PublishRequest) ProtoMessage()    {}
 func (*PublishRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_d57130a52f246854, []int{0}
+	return fileDescriptor_00212fb1f9d3bf1c, []int{0}
 }
+
 func (m *PublishRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PublishRequest.Unmarshal(m, b)
 }
 func (m *PublishRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_PublishRequest.Marshal(b, m, deterministic)
 }
-func (dst *PublishRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_PublishRequest.Merge(dst, src)
+func (m *PublishRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PublishRequest.Merge(m, src)
 }
 func (m *PublishRequest) XXX_Size() int {
 	return xxx_messageInfo_PublishRequest.Size(m)
@@ -78,95 +66,25 @@ func (m *PublishRequest) GetUnixTime() int64 {
 	return 0
 }
 
-func (m *PublishRequest) GetRunning() bool {
+func (m *PublishRequest) GetLog() string {
 	if m != nil {
-		return m.Running
+		return m.Log
 	}
-	return false
+	return ""
 }
 
-func (m *PublishRequest) GetMilliCpuUsage() uint64 {
+func (m *PublishRequest) GetTime() string {
 	if m != nil {
-		return m.MilliCpuUsage
+		return m.Time
 	}
-	return 0
+	return ""
 }
 
-func (m *PublishRequest) GetMemoryTotalMb() uint64 {
+func (m *PublishRequest) GetStream() string {
 	if m != nil {
-		return m.MemoryTotalMb
+		return m.Stream
 	}
-	return 0
-}
-
-func (m *PublishRequest) GetMemoryRssMb() uint64 {
-	if m != nil {
-		return m.MemoryRssMb
-	}
-	return 0
-}
-
-func (m *PublishRequest) GetMemoryLimitMb() uint64 {
-	if m != nil {
-		return m.MemoryLimitMb
-	}
-	return 0
-}
-
-func (m *PublishRequest) GetDiskUsageMb() int64 {
-	if m != nil {
-		return m.DiskUsageMb
-	}
-	return 0
-}
-
-func (m *PublishRequest) GetDiskLimitMb() int64 {
-	if m != nil {
-		return m.DiskLimitMb
-	}
-	return 0
-}
-
-func (m *PublishRequest) GetDiskReadKbps() uint64 {
-	if m != nil {
-		return m.DiskReadKbps
-	}
-	return 0
-}
-
-func (m *PublishRequest) GetDiskWriteKbps() uint64 {
-	if m != nil {
-		return m.DiskWriteKbps
-	}
-	return 0
-}
-
-func (m *PublishRequest) GetDiskReadIops() uint64 {
-	if m != nil {
-		return m.DiskReadIops
-	}
-	return 0
-}
-
-func (m *PublishRequest) GetDiskWriteIops() uint64 {
-	if m != nil {
-		return m.DiskWriteIops
-	}
-	return 0
-}
-
-func (m *PublishRequest) GetPidsCurrent() uint64 {
-	if m != nil {
-		return m.PidsCurrent
-	}
-	return 0
-}
-
-func (m *PublishRequest) GetPidsLimit() uint64 {
-	if m != nil {
-		return m.PidsLimit
-	}
-	return 0
+	return ""
 }
 
 type PublishResponse struct {
@@ -179,16 +97,17 @@ func (m *PublishResponse) Reset()         { *m = PublishResponse{} }
 func (m *PublishResponse) String() string { return proto.CompactTextString(m) }
 func (*PublishResponse) ProtoMessage()    {}
 func (*PublishResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_d57130a52f246854, []int{1}
+	return fileDescriptor_00212fb1f9d3bf1c, []int{1}
 }
+
 func (m *PublishResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PublishResponse.Unmarshal(m, b)
 }
 func (m *PublishResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_PublishResponse.Marshal(b, m, deterministic)
 }
-func (dst *PublishResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_PublishResponse.Merge(dst, src)
+func (m *PublishResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PublishResponse.Merge(m, src)
 }
 func (m *PublishResponse) XXX_Size() int {
 	return xxx_messageInfo_PublishResponse.Size(m)
@@ -202,6 +121,23 @@ var xxx_messageInfo_PublishResponse proto.InternalMessageInfo
 func init() {
 	proto.RegisterType((*PublishRequest)(nil), "PublishRequest")
 	proto.RegisterType((*PublishResponse)(nil), "PublishResponse")
+}
+
+func init() { proto.RegisterFile("api.proto", fileDescriptor_00212fb1f9d3bf1c) }
+
+var fileDescriptor_00212fb1f9d3bf1c = []byte{
+	// 172 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xe2, 0x4c, 0x2c, 0xc8, 0xd4,
+	0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x57, 0xca, 0xe6, 0xe2, 0x0b, 0x28, 0x4d, 0xca, 0xc9, 0x2c, 0xce,
+	0x08, 0x4a, 0x2d, 0x2c, 0x4d, 0x2d, 0x2e, 0x11, 0x92, 0xe6, 0xe2, 0x2c, 0xcd, 0xcb, 0xac, 0x88,
+	0x2f, 0xc9, 0xcc, 0x4d, 0x95, 0x60, 0x54, 0x60, 0xd4, 0x60, 0x0e, 0xe2, 0x00, 0x09, 0x84, 0x64,
+	0xe6, 0xa6, 0x0a, 0x09, 0x70, 0x31, 0xe7, 0xe4, 0xa7, 0x4b, 0x30, 0x29, 0x30, 0x6a, 0x70, 0x06,
+	0x81, 0x98, 0x42, 0x42, 0x5c, 0x2c, 0x60, 0x95, 0xcc, 0x60, 0x21, 0x30, 0x5b, 0x48, 0x8c, 0x8b,
+	0xad, 0xb8, 0xa4, 0x28, 0x35, 0x31, 0x57, 0x82, 0x05, 0x2c, 0x0a, 0xe5, 0x29, 0x09, 0x72, 0xf1,
+	0xc3, 0x2d, 0x2b, 0x2e, 0xc8, 0xcf, 0x2b, 0x4e, 0x35, 0xb2, 0xe1, 0xe2, 0x72, 0x4c, 0x4f, 0x2f,
+	0x4a, 0x4d, 0x4f, 0x2c, 0xc9, 0x2f, 0x12, 0xd2, 0xe3, 0x62, 0x87, 0x2a, 0x10, 0xe2, 0xd7, 0x43,
+	0x75, 0x97, 0x94, 0x80, 0x1e, 0x9a, 0x5e, 0x25, 0x86, 0x24, 0x36, 0xb0, 0x27, 0x8c, 0x01, 0x01,
+	0x00, 0x00, 0xff, 0xff, 0x51, 0x48, 0xab, 0xc9, 0xd1, 0x00, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -241,6 +177,14 @@ type AggregatorServer interface {
 	Publish(context.Context, *PublishRequest) (*PublishResponse, error)
 }
 
+// UnimplementedAggregatorServer can be embedded to have forward compatible implementations.
+type UnimplementedAggregatorServer struct {
+}
+
+func (*UnimplementedAggregatorServer) Publish(ctx context.Context, req *PublishRequest) (*PublishResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Publish not implemented")
+}
+
 func RegisterAggregatorServer(s *grpc.Server, srv AggregatorServer) {
 	s.RegisterService(&_Aggregator_serviceDesc, srv)
 }
@@ -274,33 +218,4 @@ var _Aggregator_serviceDesc = grpc.ServiceDesc{
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "api.proto",
-}
-
-func init() { proto.RegisterFile("api.proto", fileDescriptor_api_d57130a52f246854) }
-
-var fileDescriptor_api_d57130a52f246854 = []byte{
-	// 358 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x64, 0x92, 0xcf, 0x4b, 0xe3, 0x40,
-	0x14, 0x80, 0x37, 0xdb, 0x6e, 0xdb, 0xbc, 0xfe, 0xda, 0x9d, 0xd3, 0xb0, 0xcb, 0x42, 0x0c, 0x22,
-	0x39, 0xe5, 0xa0, 0x57, 0x2f, 0xd2, 0x93, 0x68, 0x41, 0x42, 0xc5, 0xe3, 0x90, 0x34, 0x43, 0x1c,
-	0x9a, 0x64, 0xc6, 0xf9, 0x81, 0xfa, 0x27, 0xf8, 0x5f, 0xcb, 0xbc, 0xb4, 0xb5, 0xad, 0xc7, 0x7c,
-	0x7c, 0xf9, 0xf2, 0x5e, 0x78, 0x10, 0xe6, 0x4a, 0xa4, 0x4a, 0x4b, 0x2b, 0xe3, 0x8f, 0x3e, 0xcc,
-	0x1e, 0x5c, 0x51, 0x0b, 0xf3, 0x9c, 0xf1, 0x17, 0xc7, 0x8d, 0x25, 0xff, 0x20, 0x74, 0xad, 0x78,
-	0x63, 0x56, 0x34, 0x9c, 0x06, 0x51, 0x90, 0xf4, 0xb2, 0x91, 0x07, 0x2b, 0xd1, 0x70, 0x42, 0x61,
-	0xa8, 0x5d, 0xdb, 0x8a, 0xb6, 0xa2, 0x3f, 0xa3, 0x20, 0x19, 0x65, 0xbb, 0x47, 0x72, 0x01, 0xf3,
-	0x46, 0xd4, 0xb5, 0x60, 0x6b, 0xe5, 0x98, 0x33, 0x79, 0xc5, 0x69, 0x2f, 0x0a, 0x92, 0x7e, 0x36,
-	0x45, 0xbc, 0x50, 0xee, 0xd1, 0x43, 0xf4, 0x78, 0x23, 0xf5, 0x3b, 0xb3, 0xd2, 0xe6, 0x35, 0x6b,
-	0x0a, 0xda, 0xdf, 0x7a, 0x88, 0x57, 0x9e, 0x2e, 0x0b, 0x12, 0xc3, 0x16, 0x30, 0x6d, 0x8c, 0xb7,
-	0x7e, 0xa1, 0x35, 0xee, 0x60, 0x66, 0xcc, 0xb2, 0x38, 0x68, 0xd5, 0xa2, 0x11, 0xd6, 0x5b, 0x83,
-	0xc3, 0xd6, 0xbd, 0xa7, 0x5d, 0xab, 0x14, 0x66, 0xd3, 0x8d, 0xe5, 0xad, 0x61, 0x14, 0x24, 0x24,
-	0x1b, 0x7b, 0x88, 0x53, 0x1d, 0x38, 0xfb, 0xd2, 0xe8, 0xcb, 0xd9, 0x75, 0xce, 0x61, 0x86, 0x8e,
-	0xe6, 0x79, 0xc9, 0x36, 0x85, 0x32, 0x34, 0xc4, 0xcf, 0x4d, 0x3c, 0xcd, 0x78, 0x5e, 0xde, 0x15,
-	0xca, 0xf8, 0xa9, 0xd0, 0x7a, 0xd5, 0xc2, 0xf2, 0x4e, 0x83, 0x6e, 0x2a, 0x8f, 0x9f, 0x3c, 0x45,
-	0xef, 0xa8, 0x26, 0xa4, 0x32, 0x74, 0x7c, 0x5c, 0xbb, 0x95, 0xdf, 0x6a, 0xa8, 0x4d, 0x4e, 0x6a,
-	0xe8, 0x9d, 0xc1, 0x44, 0x89, 0xd2, 0xb0, 0xb5, 0xd3, 0x9a, 0xb7, 0x96, 0x4e, 0xbb, 0xdf, 0xe5,
-	0xd9, 0xa2, 0x43, 0xe4, 0x3f, 0x00, 0x2a, 0xb8, 0x22, 0x9d, 0xa1, 0x10, 0x7a, 0x82, 0xfb, 0xc5,
-	0x7f, 0x60, 0xbe, 0x3f, 0x05, 0xa3, 0x64, 0x6b, 0xf8, 0xe5, 0x35, 0xc0, 0x4d, 0x55, 0x69, 0x5e,
-	0xe5, 0x56, 0x6a, 0x92, 0xc2, 0x70, 0x2b, 0x90, 0x79, 0x7a, 0x7c, 0x35, 0x7f, 0x7f, 0xa7, 0x27,
-	0xef, 0xc6, 0x3f, 0x8a, 0x01, 0xde, 0xd8, 0xd5, 0x67, 0x00, 0x00, 0x00, 0xff, 0xff, 0x8e, 0x40,
-	0xc6, 0x69, 0x70, 0x02, 0x00, 0x00,
 }

--- a/api/api.proto
+++ b/api/api.proto
@@ -1,28 +1,14 @@
 syntax = "proto3";
 
 service Aggregator {
-	rpc Publish (PublishRequest) returns (PublishResponse) {}
+    rpc Publish (PublishRequest) returns (PublishResponse) {}
 }
 
-// NOTE: Protocol buffers used variable-length encoding, so even though uint64
-// is arguably much bigger than we'd need, it's simpler to just use that. We
-// do, however, use signed ints for disk usage and limit because those fields
-// are optional (and should not be reported if they are < 0).
 message PublishRequest {
-	int64 unix_time = 1;
-	bool running = 2;
-	uint64 milli_cpu_usage = 3;
-	uint64 memory_total_mb = 4;
-	uint64 memory_rss_mb = 5;
-	uint64 memory_limit_mb = 6;
-	sint64 disk_usage_mb = 7;
-	sint64 disk_limit_mb = 8;
-	uint64 disk_read_kbps = 9;
-	uint64 disk_write_kbps = 10;
-	uint64 disk_read_iops = 11;
-	uint64 disk_write_iops = 12;
-	uint64 pids_current = 13;
-	uint64 pids_limit = 14;
+    int64 unix_time = 1;
+    string log = 2;
+    string time = 3;
+    string stream = 4;
 }
 
 message PublishResponse {

--- a/batch/entry.go
+++ b/batch/entry.go
@@ -1,7 +1,7 @@
 package batch
 
 import (
-	"github.com/aptible/mini-collector/api"
+	"github.com/aptible/mega-collector/api"
 	"time"
 )
 

--- a/batcher/batcher.go
+++ b/batcher/batcher.go
@@ -2,8 +2,8 @@ package batcher
 
 import (
 	"context"
-	"github.com/aptible/mini-collector/batch"
-	"github.com/aptible/mini-collector/emitter"
+	"github.com/aptible/mega-collector/batch"
+	"github.com/aptible/mega-collector/emitter"
 	"github.com/sirupsen/logrus"
 	"time"
 )
@@ -72,7 +72,6 @@ func (b *batcher) run(ctx context.Context) {
 
 	// TODO: Need to drainBatch without the cancelled context here!
 }
-
 func (b *batcher) prepareBatch(id uint64, ctx context.Context) batch.Batch {
 	currentBatch := batch.Batch{
 		Id:      id,

--- a/batcher/batcher_test.go
+++ b/batcher/batcher_test.go
@@ -2,7 +2,7 @@ package batcher
 
 import (
 	"context"
-	"github.com/aptible/mini-collector/batch"
+	"github.com/aptible/mega-collector/batch"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"

--- a/batcher/types.go
+++ b/batcher/types.go
@@ -2,7 +2,7 @@ package batcher
 
 import (
 	"context"
-	"github.com/aptible/mini-collector/batch"
+	"github.com/aptible/mega-collector/batch"
 )
 
 type Batcher interface {

--- a/emitter/blackhole/blackhole.go
+++ b/emitter/blackhole/blackhole.go
@@ -2,8 +2,8 @@ package blackhole
 
 import (
 	"context"
-	"github.com/aptible/mini-collector/batch"
-	"github.com/aptible/mini-collector/emitter"
+	"github.com/aptible/mega-collector/batch"
+	"github.com/aptible/mega-collector/emitter"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/emitter/hold/hold.go
+++ b/emitter/hold/hold.go
@@ -3,8 +3,8 @@ package hold
 import (
 	"context"
 	"fmt"
-	"github.com/aptible/mini-collector/batch"
-	"github.com/aptible/mini-collector/emitter"
+	"github.com/aptible/mega-collector/batch"
+	"github.com/aptible/mega-collector/emitter"
 	"github.com/sirupsen/logrus"
 	"sync"
 	"time"

--- a/emitter/hold/hold_test.go
+++ b/emitter/hold/hold_test.go
@@ -2,7 +2,7 @@ package hold
 
 import (
 	"context"
-	"github.com/aptible/mini-collector/batch"
+	"github.com/aptible/mega-collector/batch"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"

--- a/emitter/notify/notify.go
+++ b/emitter/notify/notify.go
@@ -10,8 +10,8 @@ import (
 	"context"
 	"fmt"
 	pagerduty "github.com/PagerDuty/go-pagerduty"
-	"github.com/aptible/mini-collector/batch"
-	"github.com/aptible/mini-collector/emitter"
+	"github.com/aptible/mega-collector/batch"
+	"github.com/aptible/mega-collector/emitter"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/emitter/text/text.go
+++ b/emitter/text/text.go
@@ -3,7 +3,7 @@ package text
 import (
 	"context"
 	"fmt"
-	"github.com/aptible/mini-collector/batch"
+	"github.com/aptible/mega-collector/batch"
 )
 
 type textEmitter struct{}

--- a/emitter/types.go
+++ b/emitter/types.go
@@ -2,7 +2,7 @@ package emitter
 
 import (
 	"context"
-	"github.com/aptible/mini-collector/batch"
+	"github.com/aptible/mega-collector/batch"
 )
 
 type Emitter interface {

--- a/emitter/writer/types.go
+++ b/emitter/writer/types.go
@@ -1,7 +1,7 @@
 package writer
 
 import (
-	"github.com/aptible/mini-collector/batch"
+	"github.com/aptible/mega-collector/batch"
 )
 
 type Writer interface {

--- a/emitter/writer/writer.go
+++ b/emitter/writer/writer.go
@@ -3,8 +3,8 @@ package writer
 import (
 	"context"
 	"fmt"
-	"github.com/aptible/mini-collector/batch"
-	"github.com/aptible/mini-collector/emitter"
+	"github.com/aptible/mega-collector/batch"
+	"github.com/aptible/mega-collector/emitter"
 	"github.com/sirupsen/logrus"
 	"time"
 )

--- a/emitter/writer/writer_test.go
+++ b/emitter/writer/writer_test.go
@@ -3,8 +3,8 @@ package writer
 import (
 	"context"
 	"fmt"
-	"github.com/aptible/mini-collector/batch"
-	"github.com/aptible/mini-collector/emitter/blackhole"
+	"github.com/aptible/mega-collector/batch"
+	"github.com/aptible/mega-collector/emitter/blackhole"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"


### PR DESCRIPTION
The only meaningful change is to `api/api.proto` (and, by extension, `api/api.pb.go`, since that's auto-generated from `api/api.proto`).

The real issue is that `api/api.proto` is a core object, and so changing it has far reaching implications. For example it's referenced in:

* server creation: https://github.com/aptible/mini-collector/blob/5c435a7ede90128630882d6095480b9c89fe7c7b/cmd/aggregator/main.go#L58
 * batch entries: https://github.com/aptible/mini-collector/blob/5c435a7ede90128630882d6095480b9c89fe7c7b/batch/entry.go#L11


More problematically, the batch entries introduces a cascading group of issues since that's referenced by the batcher (https://github.com/aptible/mini-collector/blob/5c435a7ede90128630882d6095480b9c89fe7c7b/batcher/batcher.go#L26), which in turn is referenced all over the place. So while the change itself is trivial, it has far-reaching consequences that I have yet to come up with an ideal way of addressing. Either way, this draft proves how simple the final solution for the aggregator should actually be. I haven't dug into the collector too much, but depending on how much we trust papertrail that shouldn't be too much more difficult either.


Ignore the Makefile and mini->mega changes. Those are just because I moved everything over to another repo for development (since I'm not convinced I'm going to keep both drains in the same repo yet).
  