### PR TITLE
Allow for using a custom DD endpoint

### DIFF
--- a/writer/datadog/types.go
+++ b/writer/datadog/types.go
@@ -4,6 +4,7 @@ type Config struct {
 	ApiKey     string `json:"api_key"`
 	Timeout    string `json:"timeout"`
 	RetryCount string `json:"retry_count"`
+	SeriesUrl  string `json:"series_url"`
 }
 
 type datadogPoint = []interface{}


### PR DESCRIPTION
This is a very hacky first step toward supporting EU endpoints for Datadog.

Mini-collector expects series_url to be set in the drain config. E.g.:

```
> d = MetricDrain.find(...)
> c = d.drain_configuration
> c['series_url'] = 'https://url.com/path'
> d.update_attributes!(drain_configuration: c)
```

Feel free to ask for info about how I tested or testing instructions.